### PR TITLE
Issue-#39: Read all params in initialization of config manager

### DIFF
--- a/src/AI/ChatCommands/UserDataChatCommand.cpp
+++ b/src/AI/ChatCommands/UserDataChatCommand.cpp
@@ -36,7 +36,7 @@ bool UserDataChatCommand::GetAnswer(const ChatMessage& message, QString& answer)
         QString param;
         ConfigurationManager& configMng = ConfigurationManager::Instance();
         // Get custom currency name
-        if (configMng.GetStringParam(CFGS_CURRENCY, param))
+        if (configMng.GetStringParam(CFGP_CURRENCY, param))
         {
             answer.append(param);
         }
@@ -64,7 +64,7 @@ bool UserDataChatCommand::GetAnswer(const ChatMessage& message, QString& answer)
         answer.append("; 2) ");
         QString param;
         ConfigurationManager& configMng = ConfigurationManager::Instance();
-        if (configMng.GetStringParam(CFGS_CURRENCY, param))
+        if (configMng.GetStringParam(CFGP_CURRENCY, param))
         {
             answer.append(param);
         }

--- a/src/Utils/Config/ConfigurationManager.cpp
+++ b/src/Utils/Config/ConfigurationManager.cpp
@@ -108,13 +108,8 @@ void ConfigurationManager::_ReadConfigData()
         }
         if (_xmlReader.isStartElement())
         {
-            // If found currency parameter, save it
-            if (_xmlReader.name() == CFGS_CURRENCY)
-            {
-                _params.insert(_xmlReader.name().toString(), _xmlReader.readElementText());
-            }
             // If we found ignore list section, read it
-            else if (_xmlReader.name() == CFGS_IGNORE)
+            if (_xmlReader.name() == CFGS_IGNORE)
             {
                 _ReadIgnoreList();
             }
@@ -122,6 +117,15 @@ void ConfigurationManager::_ReadConfigData()
             else if (_xmlReader.name() == CFGS_COVENANTS)
             {
                 _ReadCovenantList();
+            }
+            // If we found any other parameter, save it
+            else
+            {
+                QString value = _xmlReader.readElementText();
+                if (!value.isEmpty())
+                {
+                    _params.insert(_xmlReader.name().toString(), value);
+                }
             }
         }
     }

--- a/src/Utils/Config/ConfigurationParameters.hpp
+++ b/src/Utils/Config/ConfigurationParameters.hpp
@@ -3,12 +3,17 @@
 // Section names
 #define CFGS_LOGIN     "LoginData"
 #define CFGS_CONFIG    "ConfigData"
-#define CFGS_CURRENCY  "Currency"
 #define CFGS_IGNORE    "IgnoreList"
 #define CFGS_USER      "User"
 #define CFGS_COVENANTS "CovenantList"
 #define CFGS_COVENANT  "Covenant"
 
+/*============================================*/
+/*================ Parameters ================*/
+/*============================================*/
+/* Login params */
 #define CFGP_LOGIN_NAME       "LoginName"
 #define CFGP_LOGIN_OATH_KEY   "LoginOauthKey"
 #define CFGP_LOGIN_CHANNEL    "LoginChannel"
+/* Other params */
+#define CFGP_CURRENCY         "Currency"


### PR DESCRIPTION
Previously, config manager do not read all params that it found. But this commit fix that and all params which will be found now will be saved in config manager.