### PR TITLE
Issue-295: Bot do not recognise messages from users without name color

### DIFF
--- a/src/Chat/ChatMessage.cpp
+++ b/src/Chat/ChatMessage.cpp
@@ -37,21 +37,21 @@ QRegularExpression ChatMessage::_regExpMode(":jtv MODE #.* \\+o (?<name>.*)\\r\\
 /*** UNMODE ***/
 QRegularExpression ChatMessage::_regExpUnmode(":jtv MODE #.* -o (?<name>.*)\\r\\n");
 /*** BITS ***/
-QRegularExpression ChatMessage::_regExpBits("@badges=.*;bits=(?<bits>.*);color=(?<color>#\\w\\w\\w\\w\\w\\w);"
-                                            "display-name=(?<author>.*);emotes=.*;id=.*;"
-                                            "mod=(?<mod>\\d);room-id=.*;subscriber=(?<sub>\\d);"
-                                            ".*;turbo=.*;user-id=.*;user-type=.* "
+QRegularExpression ChatMessage::_regExpBits("@badges=.*;bits=(?<bits>.*);color=(?<color>.*);"
+                                            "display-name=(?<author>.*);.*emotes=.*;id=.*;"
+                                            "mod=(?<mod>\\d);room-id=.*;.*subscriber=(?<sub>\\d);"
+                                            ".*;turbo=\\d;user-id=.*;user-type=.* "
                                             ":(?<name>.*)!.*@.*.tmi.twitch.tv PRIVMSG #.* :(?<msg>.*)\r\n");
 /*** PRIVMSG ***/
-QRegularExpression ChatMessage::_regExpPrivmsg("@badges=.*;color=(?<color>#\\w\\w\\w\\w\\w\\w);display-name=(?<author>.*);"
+QRegularExpression ChatMessage::_regExpPrivmsg("@badges=.*;color=(?<color>.*);display-name=(?<author>.*);.*"
                                                "emotes=.*;id=.*;mod=(?<mod>\\d);"
-                                               "room-id=.*;subscriber=(?<sub>\\d);tmi-sent-ts=.*;"
+                                               "room-id=.*;.*subscriber=(?<sub>\\d);.*"
                                                "turbo=\\d;user-id=.*;user-type=.* "
                                                ":(?<name>.*)!.*@.*.tmi.twitch.tv PRIVMSG #.* :(?<msg>.*)\\r\\n");
 /*** WHISPER ***/
-QRegularExpression ChatMessage::_regExpWhisper("@badges=.*;color=(?<color>#\\w\\w\\w\\w\\w\\w);display-name=(?<author>.*);"
+QRegularExpression ChatMessage::_regExpWhisper("@badges=.*;color=(?<color>.*);display-name=(?<author>.*);"
                                                "emotes=.*;message-id=.*;thread-id=.*;"
-                                               "turbo=.*;user-id=.*;user-type=.* "
+                                               "turbo=\\d;user-id=.*;user-type=.* "
                                                ":(?<name>.*)!.*@.*.tmi.twitch.tv WHISPER .* :(?<msg>.*)\\r\\n");
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/ChatBot.pro.user
+++ b/src/ChatBot.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.2.1, 2017-07-22T03:01:28. -->
+<!-- Written by QtCreator 4.2.1, 2017-07-25T02:40:27. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>


### PR DESCRIPTION
Problem was in RegExp, where color always was #\\d\\d\\d\\d\\d\\d, but it is not what should be.