### PR TITLE
US-232: Kraken client - Live stream info

### DIFF
--- a/src/Twitch/KrakenClient.hpp
+++ b/src/Twitch/KrakenClient.hpp
@@ -29,7 +29,12 @@ enum KrakenParameter
     ChannelPartnerStatus,
     ChannelViews,
     ChannelFollowers,
-    ChannelBroadcasterType
+    ChannelBroadcasterType,
+    StreamOn,
+    StreamType,
+    StreamViewers,
+    StreamResolution,
+    StreamFPS
 };
 
 // Forward declaration
@@ -111,6 +116,13 @@ private:
      * If channel info not gained, tries to get it.
      */
     void _UpdateChannelInfo();
+    /*!
+     * \brief Tries to get stream info.
+     *
+     * Tries to get stream info to know when stream is up and how many viewers currently watching the stream..
+     */
+    void _UpdateStreamInfo();
+
 
     /*!
      * \brief Sets specified value to certain parameter.
@@ -150,6 +162,11 @@ private:
      * \param response - json object of response.
      */
     void _HandleChannelInfo(const KrakenResponse &response);
+    /*!
+     * \brief Handles stream info message from Kraken API.
+     * \param response - json object of response.
+     */
+    void _HandleStreamInfo(const KrakenResponse &response);
 
     /*! Network manager which sends and receives messages to/from Kraken API. */
     QNetworkAccessManager *_networkManager;

--- a/src/Twitch/KrakenResponse.cpp
+++ b/src/Twitch/KrakenResponse.cpp
@@ -5,8 +5,8 @@
 **************************************************************************/
 #include "KrakenResponse.hpp"
 #include <QJsonDocument>
-
-#include <QDebug>
+#include <QVariant>
+#include <QJsonArray>
 
 using namespace Twitch;
 
@@ -27,6 +27,9 @@ QVector<QString> KrakenResponse::_jsonFieldsBotStatus = {"_id", "login", "displa
 
 /* Channel info */
 QVector<QString> KrakenResponse::_jsonFieldsChannelInfo = {"mature", "status", "game", "partner", "views", "followers", "broadcaster_type"};
+
+/* Stream info */
+QVector<QString> KrakenResponse::_jsonFieldsStreamInfo = {"_total", "streams"};
 
 ///////////////////////////////////////////////////////////////////////////
 
@@ -60,6 +63,10 @@ KrakenResponseType KrakenResponse::ParseResponse(const QString &response)
         else if (_ValidateChannelInfo(jsonObject))
         {
             responseType = KrakenResponseType::ChannelInfo;
+        }
+        else if (_ValidateStreamInfo(jsonObject))
+        {
+            responseType = KrakenResponseType::StreamInfo;
         }
     }
 
@@ -110,7 +117,14 @@ bool KrakenResponse::_ValidateParams(const QVector<QString> &paramsToValidate, c
     {
         for (int i = 0; i < paramsToValidate.size(); ++i)
         {
-            _params.push_back(QPair<QString, QVariant>(paramsToValidate[i], jsonObject.value(paramsToValidate[i]).toVariant()));
+            if (jsonObject.value(paramsToValidate[i]).isArray())
+            {
+                _params.push_back(QPair<QString, QVariant>(paramsToValidate[i], jsonObject.value(paramsToValidate[i]).toArray()));
+            }
+            else
+            {
+                _params.push_back(QPair<QString, QVariant>(paramsToValidate[i], jsonObject.value(paramsToValidate[i]).toVariant()));
+            }            
         }
     }
 
@@ -143,6 +157,13 @@ bool KrakenResponse::_ValidateBotStatus(const QJsonObject &jsonObject)
 bool KrakenResponse::_ValidateChannelInfo(const QJsonObject &jsonObject)
 {
     return _ValidateParams(_jsonFieldsChannelInfo, jsonObject);
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+bool KrakenResponse::_ValidateStreamInfo(const QJsonObject &jsonObject)
+{
+    return _ValidateParams(_jsonFieldsStreamInfo, jsonObject);
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/Twitch/KrakenResponse.hpp
+++ b/src/Twitch/KrakenResponse.hpp
@@ -23,7 +23,8 @@ enum class KrakenResponseType
     Error,
     UserInfo,
     BotStatus,
-    ChannelInfo
+    ChannelInfo,
+    StreamInfo
 };
 
 /*! Simple typedef to short name. */
@@ -87,6 +88,12 @@ private:
      * \return True if specified object contains channel info fields.
      */
     bool _ValidateChannelInfo(const QJsonObject &jsonObject);
+    /*!
+     * \brief Check if specified object contains stream info fields.
+     * \param jsonObject - object that should be checked.
+     * \return True if specified object contains stream info fields.
+     */
+    bool _ValidateStreamInfo(const QJsonObject &jsonObject);
 
     /*! Array of parameters that was found in response. */
     KRParams _params;
@@ -99,6 +106,8 @@ private:
     static QVector<QString> _jsonFieldsBotStatus;
     /*! Static array of fields that should exist in channel info response. */
     static QVector<QString> _jsonFieldsChannelInfo;
+    /*! Static array of fields that should exist in stream info response. */
+    static QVector<QString> _jsonFieldsStreamInfo;
 };
 
 }


### PR DESCRIPTION
Finally, bot have real info about viewers! Because bot now periodically checking stream status to grab all kind of info about it.  Thanks to that, may functionality can be reimplemented or implemented with stream status info in mind.